### PR TITLE
Fixed OBD adapter not working by removing obd.sleep

### DIFF
--- a/megaloggerHD/megaloggerHD.ino
+++ b/megaloggerHD/megaloggerHD.ino
@@ -575,7 +575,6 @@ void reconnect()
         if (obd.init())
             break;
         
-        obd.sleep();
         Narcoleptic.delay(10000);
     }
     // re-initialize


### PR DESCRIPTION
Uploading the current sketch revision for megaloggerHD results in a compile error, this is resolved by removing obd.sleep().

The sketch is tested to work using an OBD-II adapter and Arduino Mega 2560